### PR TITLE
Fixes setting sign text for before update(boolean, boolean) was added

### DIFF
--- a/src/main/java/ch/njol/skript/expressions/ExprSignText.java
+++ b/src/main/java/ch/njol/skript/expressions/ExprSignText.java
@@ -148,7 +148,7 @@ public class ExprSignText extends SimpleExpression<String> {
 				s.setLine(line, (String) delta[0]);
 				break;
 		}
-		s.update(false, false);
+		s.update();
 	}
 	
 	@Override


### PR DESCRIPTION
The advantages of using update(false, false) are outweighed by the fact that it breaks versions such as 1.4.7 that didn't have the method.
Completes Ticket 286
