### PR TITLE
Update Factions2Hook.java

### DIFF
--- a/src/main/java/ch/njol/skript/hooks/regions/Factions2Hook.java
+++ b/src/main/java/ch/njol/skript/hooks/regions/Factions2Hook.java
@@ -215,7 +215,7 @@ public class Factions2Hook extends RegionsPlugin<Factions> {
 	@SuppressWarnings("null")
 	@Override
 	public Collection<? extends Region> getRegionsAt_i(final Location l) {
-		return Arrays.asList(new FactionsRegion(BoardColls.get().getFactionAt(PS.valueOf(l))));
+		return Arrays.asList(new FactionsRegion(BoardColl.get().getFactionAt(PS.valueOf(l)).getName()));
 	}
 	
 	@Override


### PR DESCRIPTION
Current version returns error 
"at ch.njol.skript.hooks.regions.Factions2Hook.getRegionsAt_i(Factions2Hook.java:218) ~[?:?]"
Whenever used. My code aim's to fix it. I've used it in my addon FactionSk and it worked without errors.

Ofcourse it may not actually work, and I can't be bothered building my own version of Skript to test :smile: 
